### PR TITLE
Set rendered option when control is rendered

### DIFF
--- a/src/IPub/FormDateTime/Controls/BaseControl.php
+++ b/src/IPub/FormDateTime/Controls/BaseControl.php
@@ -264,6 +264,8 @@ abstract class BaseControl extends Forms\Controls\BaseControl
 	 */
 	public function getControl()
 	{
+		$this->setOption('rendered', TRUE);
+
 		// If template file was not defined before...
 		if ($this->template->getFile() === NULL) {
 			// ...try to get base control template file


### PR DESCRIPTION
Rendered option is used by some form renderers to detect already rendered controls. 

For example when form is rendered using instante/bootstrap3renderer without this flag controls are rendered twice if they are inside group.