### PR TITLE
Fixed data type in passing parameters to JS

### DIFF
--- a/src/IPub/FormDateTime/Controls/Date.php
+++ b/src/IPub/FormDateTime/Controls/Date.php
@@ -369,7 +369,7 @@ class Date extends BaseControl
 				// Day of the week start. 0 (Sunday) to 6 (Saturday)
 				'weekStart'				=> $this->weekStart,
 				// Whether or not to close the date picker immediately when a date is selected
-				'autoclose'				=> $this->autoclose ? 'true' : 'false',
+				'autoclose'				=> (bool) $this->autoclose,
 				// The view that the date picker should show when it is opened
 				'startView'				=> self::START_VIEW_MONTH,
 				// The lowest view that the date picker should show

--- a/src/IPub/FormDateTime/Controls/DateTime.php
+++ b/src/IPub/FormDateTime/Controls/DateTime.php
@@ -173,9 +173,9 @@ class DateTime extends Date
 			// The time format, combination of p, P, h, hh, i, ii, s, ss, d, dd, m, mm, M, MM, yy, yyyy
 			'format'				=> $this->timeFormat,
 			// Enable or disable meridian views
-			'showMeridian'			=> $this->showMeridian ? 'true' : 'false',
+			'showMeridian'			=> (bool) $this->showMeridian,
 			// Whether or not to close the date picker immediately when a date is selected
-			'autoclose'				=> $this->autoclose ? 'true' : 'false',
+			'autoclose'				=> (bool) $this->autoclose,
 			// The lowest view that the date picker should show
 			'startView'				=> self::START_VIEW_DAY,
 			// The lowest view that the date picker should show

--- a/src/IPub/FormDateTime/Controls/Time.php
+++ b/src/IPub/FormDateTime/Controls/Time.php
@@ -179,9 +179,9 @@ class Time extends BaseControl
 				// The time format, combination of p, P, h, hh, i, ii, s, ss, d, dd, m, mm, M, MM, yy, yyyy
 				'format'				=> $this->timeFormat,
 				// Enable or disable meridian views
-				'showMeridian'			=> $this->showMeridian ? 'true' : 'false',
+				'showMeridian'			=> (bool) $this->showMeridian,
 				// Whether or not to close the date picker immediately when a date is selected
-				'autoclose'				=> $this->autoclose ? 'true' : 'false',
+				'autoclose'				=> (bool) $this->autoclose,
 				// The lowest view that the date picker should show
 				'startView'				=> self::START_VIEW_HOUR,
 				// The lowest view that the date picker should show


### PR DESCRIPTION
In passing parameters to JS boolean value false was converted to string "false" which was interpreted as logical true.

Based on PR #4 by @merglv